### PR TITLE
use "deployment_image" for drone v0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### Usage
 
-
+For usage in drone v1.0:
 ```
 kind: pipeline
 name: default
@@ -32,3 +32,27 @@ steps:
         from_secret: api_key_prod
 ```
 
+For usage in drone v0.8:
+```
+kind: pipeline
+name: default
+
+steps:
+  - name: deploy-using-new-drone-plugin-version
+    image: oliver006/drone-cloud-run:latest
+    pull: always
+
+    # plugin settings are top-level
+    action: deploy
+    service: my-api-service
+    deployment_image: org-name/my-api-service-image
+    memory: 512Mi
+    region: us-central1
+    allow_unauthenticated: true
+    secrets:
+      - source: google_credentials
+        target: token
+      - source: api_key_prod
+        target: env_secret_api_key
+
+```

--- a/main.go
+++ b/main.go
@@ -86,7 +86,11 @@ func parseConfig() (*Config, error) {
 		return nil, fmt.Errorf("Missing service name")
 	}
 	if cfg.ImageName == "" {
-		return nil, fmt.Errorf("Missing image name")
+		// for Drone v0.8 compat. as 'image' clashes since settings are passed top-level
+		cfg.ImageName = os.Getenv("PLUGIN_DEPLOYMENT_IMAGE")
+		if cfg.ImageName == "" {
+			return nil, fmt.Errorf("Missing image/deployment_image name")
+		}
 	}
 
 	if cfg.Token == "" {

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,13 @@ func TestParseConfig(t *testing.T) {
 			expectedEnvSecrets: []string{"API_KEY=secret"},
 		},
 
+		// use PLUGIN_DEPLOYMENT_IMAGE instead of PLUGIN_IMAGE, old drone :/
+		{
+			expectedToBeOk:    true,
+			Env:               map[string]string{"PLUGIN_ACTION": "deploy", "PLUGIN_TOKEN": validGCPKey, "PLUGIN_SERVICE": "my-service", "PLUGIN_DEPLOYMENT_IMAGE": "my-image"},
+			expectedProjectId: "my-project-id",
+		},
+
 		// use TOKEN instead of PLUGIN_TOKEN, old drone :-/
 		{
 			expectedToBeOk:    true,


### PR DESCRIPTION
# why

In drone 0.8, settings are passed as top level key-values in the job. This is an issue because the key "image" creates a collision with the job's container in the yaml definition. So, perhaps we could also check another key `deployment_image` so folks using drone 0.8 could use this as well.

# what

this pr:
- allows an env `PLUGIN_DEPLOYMENT_IMAGE` which would mean a key `deployment_image`
