### PR TITLE
Add cloud sql instance flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ steps:
       memory: 512Mi
       region: us-central1
       allow_unauthenticated: true
-      cloud_sql_instances: +instance1,instance2
+      addl_flags: 
+        add-cloud-sql-instances: instance1,instance2
       token:
         from_secret: google_credentials
       environment:
@@ -48,6 +49,8 @@ steps:
     memory: 512Mi
     region: us-central1
     allow_unauthenticated: true
+    addl_flags:
+      clear-cloudsql-instances: ''
     secrets:
       - source: google_credentials
         target: token
@@ -56,30 +59,13 @@ steps:
 
 ```
 
-### On CloudSqlInstances
 
-For the `gcloud` flags related to [modifying cloud sql instances](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--add-cloudsql-instances) connected to the service,
+## On Additional Flags
 
-```
+To be flexible with respect to flags that the `gcloud` command can accept, you
+can use `addl_flags` in your drone setup settings. Use the flags are they're described
+in the [documentation](https://cloud.google.com/sdk/gcloud/reference/run/deploy) without
+the prefix `--` (eg. `--set-config-maps` becomes `set-config-maps`). If the flag doesn't
+require any arguments, use `''` as the value.
 
---add-cloudsql-instances=[CLOUDSQL-INSTANCES,…]
-    Append the given values to the current Cloud SQL instances. 
---clear-cloudsql-instances
-    Empty the current Cloud SQL instances. 
---remove-cloudsql-instances=[CLOUDSQL-INSTANCES,…]
-    Remove the given values from the current Cloud SQL instances. 
---set-cloudsql-instances=[CLOUDSQL-INSTANCES,…]
-    Completely replace the current Cloud SQL instances with the given values. 
-```
-
-we provide a singular field `cloud_sql_update` since you can only set at most one.
-
-To use it, here are some examples:
-
-| arg                             | written as |
-|---------------------------------|------------|
-| --add-cloudsql-instances=a,b,e  | +abc       |
-| --clear-cloudsql-instances      | #          |
-| --remove-cloudsql-instances=a,c | -a,c       |
-| --set-cloudsql-instances=a,d,c  | =a,d,c     |
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ steps:
       memory: 512Mi
       region: us-central1
       allow_unauthenticated: true
+      cloud_sql_instances: +instance1,instance2
       token:
         from_secret: google_credentials
       environment:
@@ -54,4 +55,31 @@ steps:
         target: env_secret_api_key
 
 ```
+
+### On CloudSqlInstances
+
+For the `gcloud` flags related to [modifying cloud sql instances](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--add-cloudsql-instances) connected to the service,
+
+```
+
+--add-cloudsql-instances=[CLOUDSQL-INSTANCES,…]
+    Append the given values to the current Cloud SQL instances. 
+--clear-cloudsql-instances
+    Empty the current Cloud SQL instances. 
+--remove-cloudsql-instances=[CLOUDSQL-INSTANCES,…]
+    Remove the given values from the current Cloud SQL instances. 
+--set-cloudsql-instances=[CLOUDSQL-INSTANCES,…]
+    Completely replace the current Cloud SQL instances with the given values. 
+```
+
+we provide a singular field `cloud_sql_update` since you can only set at most one.
+
+To use it, here are some examples:
+
+| arg                             | written as |
+|---------------------------------|------------|
+| --add-cloudsql-instances=a,b,e  | +abc       |
+| --clear-cloudsql-instances      | #          |
+| --remove-cloudsql-instances=a,c | -a,c       |
+| --set-cloudsql-instances=a,d,c  | =a,d,c     |
 

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func parseConfig() (*Config, error) {
 	addlFlagsStr := os.Getenv("PLUGIN_ADDL_FLAGS")
 	if err := json.Unmarshal([]byte(addlFlagsStr), &cfg.AdditionalFlags); err != nil && addlFlagsStr != "" {
 		log.Printf("json.Unmarshal() err: %s", err)
-		log.Printf("os.Getenv(PLUGIN_ADDL_FLAGS): %s", envStr)
+		log.Printf("os.Getenv(PLUGIN_ADDL_FLAGS): %s", addlFlagsStr)
 		return nil, fmt.Errorf("failed to parse additional flags: [%s]", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ type Config struct {
 	Environment          map[string]string
 	EnvSecrets           []string
 
-	AdditionalFlags 	 map[string]string
+	AdditionalFlags map[string]string
 }
 
 const (
@@ -189,7 +189,7 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 		}
 
 		for flg, argStr := range cfg.AdditionalFlags {
-			args = append(args, "--" + flg, argStr)
+			args = append(args, "--"+flg, argStr)
 		}
 
 	default:

--- a/main.go
+++ b/main.go
@@ -189,7 +189,11 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 		}
 
 		for flg, argStr := range cfg.AdditionalFlags {
-			args = append(args, "--"+flg, argStr)
+			if argStr != "" {
+				args = append(args, fmt.Sprintf("--%s=%s", flg, argStr))
+			} else {
+				args = append(args, fmt.Sprintf("--%s", flg))
+			}
 		}
 
 	default:

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func parseConfig() (*Config, error) {
 	if err := json.Unmarshal([]byte(addlFlagsStr), &cfg.AdditionalFlags); err != nil && addlFlagsStr != "" {
 		log.Printf("json.Unmarshal() err: %s", err)
 		log.Printf("os.Getenv(PLUGIN_ADDL_FLAGS): %s", envStr)
+		return nil, fmt.Errorf("failed to parse additional flags: [%s]", err)
 	}
 
 	PluginEnvSecretPrefix := "PLUGIN_ENV_SECRET_"

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ type Config struct {
 	Timeout              string
 	Environment          map[string]string
 	EnvSecrets           []string
+
+	CloudSQLUpdate string
 }
 
 const (
@@ -71,6 +73,7 @@ func parseConfig() (*Config, error) {
 		Concurrency:          os.Getenv("PLUGIN_CONCURRENCY"),
 		Memory:               os.Getenv("PLUGIN_MEMORY"),
 		Timeout:              os.Getenv("PLUGIN_TIMEOUT"),
+		CloudSQLUpdate:       os.Getenv("PLUGIN_CLOUD_SQL_UPDATE"),
 	}
 
 	envStr := os.Getenv("PLUGIN_ENVIRONMENT")
@@ -164,6 +167,21 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 
 		if cfg.Region != "" {
 			args = append(args, "--region", cfg.Region)
+		}
+
+		if cfg.CloudSQLUpdate != "" {
+			switch cfg.CloudSQLUpdate[0] {
+			case '+':
+				args = append(args, "--add-cloud-sql-instances", cfg.CloudSQLUpdate[1:])
+			case '-':
+				args = append(args, "--remove-cloud-sql-instances", cfg.CloudSQLUpdate[1:])
+			case '#':
+				args = append(args, "--clear-cloud-sql-instances")
+			case '=':
+				args = append(args, "--set-cloud-sql-instances", cfg.CloudSQLUpdate[1:])
+			default:
+				return []string{}, fmt.Errorf("cloudsqlupdate improperly formatted: first char != {+-=c}")
+			}
 		}
 
 	default:

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func parseConfig() (*Config, error) {
 	}
 
 	addlFlagsStr := os.Getenv("PLUGIN_ADDL_FLAGS")
-	if err := json.Unmarshal([]byte(envStr), &cfg.AdditionalFlags); err != nil && addlFlagsStr != "" {
+	if err := json.Unmarshal([]byte(addlFlagsStr), &cfg.AdditionalFlags); err != nil && addlFlagsStr != "" {
 		log.Printf("json.Unmarshal() err: %s", err)
 		log.Printf("os.Getenv(PLUGIN_ADDL_FLAGS): %s", envStr)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -132,6 +132,7 @@ func TestParseAndRunConfig(t *testing.T) {
 				"PLUGIN_MEMORY":                "128Mi",
 				"PLUGIN_TIMEOUT":               "10s",
 				"PLUGIN_REGION":                "us-central1",
+				"PLUGIN_CLOUD_SQL_UPDATE":      "-my-proj:east2:db2",
 			},
 			cfgExpectedProjectId: "my-project-id",
 			planExpectedOk:       true,

--- a/main_test.go
+++ b/main_test.go
@@ -89,6 +89,7 @@ func TestParseAndRunConfig(t *testing.T) {
 		cfgExpectedEnvSecrets []string
 		cfgExpectedEnvKeys    []string
 		planExpectedOk        bool
+		planExpectedFlags     []string
 	}{
 		{
 			cfgExpectedOk:        true,
@@ -115,7 +116,7 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedOk:        true,
 			env:                  map[string]string{"PLUGIN_ACTION": "deploy", "PLUGIN_TOKEN": validGCPKey, "PLUGIN_ENVIRONMENT": `    `, "PLUGIN_SERVICE": "my-service", "PLUGIN_IMAGE": "my-image"},
 			cfgExpectedProjectId: "my-project-id",
-			cfgExpectedEnvKeys:   []string{"VAR_1=var01", "VERSION=d0c13cb8646875cf94387f0d3de4e92b85eee3b0"},
+			cfgExpectedEnvKeys:   []string{},
 			planExpectedOk:       true,
 		},
 
@@ -133,10 +134,11 @@ func TestParseAndRunConfig(t *testing.T) {
 				"PLUGIN_MEMORY":                "128Mi",
 				"PLUGIN_TIMEOUT":               "10s",
 				"PLUGIN_REGION":                "us-central1",
-				"PLUGIN_CLOUD_SQL_UPDATE":      "-my-proj:east2:db2",
+				"PLUGIN_ADDL_FLAGS":            `{"remove-cloudsql-instances":"my-proj:east2:db2"}`,
 			},
 			cfgExpectedProjectId: "my-project-id",
 			planExpectedOk:       true,
+			planExpectedFlags:    []string{"--remove-cloudsql-instances=my-proj:east2:db2"},
 		},
 
 		// parses ok but action is unknown
@@ -215,19 +217,11 @@ func TestParseAndRunConfig(t *testing.T) {
 			env: map[string]string{
 				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
 				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
-				"PLUGIN_CLOUD_SQL_UPDATE": "doesnt-start-with-modifier"},
+				"PLUGIN_ADDL_FLAGS": `{"add-cloud-sql-instances": "instance1,instance2", "clear-config-maps": ""}`},
 			cfgExpectedOk:        true,
-			planExpectedOk:       false,
+			planExpectedOk:       true,
 			cfgExpectedProjectId: "my-project-id",
-		},
-		{
-			env: map[string]string{
-				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
-				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
-				"PLUGIN_CLOUD_SQL_UPDATE": "&wrong-modifier"},
-			cfgExpectedOk:        true,
-			planExpectedOk:       false,
-			cfgExpectedProjectId: "my-project-id",
+			planExpectedFlags:    []string{"--add-cloud-sql-instances=instance1,instance2", "--clear-config-maps"},
 		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
@@ -284,6 +278,19 @@ func TestParseAndRunConfig(t *testing.T) {
 				t.Fatalf("Expected plan to fail, got plan: %v   env: %#v", plan, tst.env)
 			}
 			t.Logf("plan: %v", plan)
+
+			for _, flg := range tst.planExpectedFlags {
+				found := false
+				for _, pflg := range plan {
+					if pflg == flg {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("couldn't find expected flag [%s] in [%v]", flg, plan)
+				}
+			}
 
 			GCloudCommand = "/bin/echo"
 			err = runConfig(cfg)

--- a/main_test.go
+++ b/main_test.go
@@ -219,6 +219,15 @@ func TestParseAndRunConfig(t *testing.T) {
 			planExpectedOk:       false,
 			cfgExpectedProjectId: "my-project-id",
 		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_CLOUD_SQL_UPDATE": "&wrong-modifier"},
+			cfgExpectedOk:        true,
+			planExpectedOk:       false,
+			cfgExpectedProjectId: "my-project-id",
+		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
 		t.Run(name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -210,6 +210,15 @@ func TestParseAndRunConfig(t *testing.T) {
 			env:                  map[string]string{"PLUGIN_ACTION": "", "PLUGIN_SERVICE": "my-service"},
 			cfgExpectedProjectId: "my-project-id",
 		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_CLOUD_SQL_UPDATE": "doesnt-start-with-modifier"},
+			cfgExpectedOk:        true,
+			planExpectedOk:       false,
+			cfgExpectedProjectId: "my-project-id",
+		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
 		t.Run(name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -217,7 +217,7 @@ func TestParseAndRunConfig(t *testing.T) {
 			env: map[string]string{
 				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
 				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
-				"PLUGIN_ADDL_FLAGS": `{"add-cloud-sql-instances": "instance1,instance2", "clear-config-maps": ""}`},
+				"PLUGIN_ADDL_FLAGS": `{"add-cloud-sql-instances":"instance1,instance2","clear-config-maps":""}`},
 			cfgExpectedOk:        true,
 			planExpectedOk:       true,
 			cfgExpectedProjectId: "my-project-id",

--- a/main_test.go
+++ b/main_test.go
@@ -223,6 +223,14 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedProjectId: "my-project-id",
 			planExpectedFlags:    []string{"--add-cloud-sql-instances=instance1,instance2", "--clear-config-maps"},
 		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_ADDL_FLAGS": `{"impossible-structure`},
+			cfgExpectedOk:        false,
+			cfgExpectedProjectId: "my-project-id",
+		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
# why

there was an issue that i got notified of about adding
support for the set of cloud sql instance command line flags [here](https://github.com/oliver006/drone-cloud-run/issues/3).

notes:
- since you can only set one i used a notation that i describe in 
the readme. i dunno if thats good or bad. i felt it was nice because
it encodes the "only use one flag" rather easily.

# what
this pr:
- adds support for the cloud sql instances changes