### PR TITLE
Allow Setting Runtime SvcAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ steps:
     settings:
       action: deploy
       service: my-api-service
+      runtime: gke                                              # default=managed
       image: org-name/my-api-service-image
       memory: 512Mi
       region: us-central1
-      allow_unauthenticated: true
+      allow_unauthenticated: true                               # default=false
+      svc_account: 1234-my-svc-account@google.svcaccount.com    
       token:
         from_secret: google_credentials
       environment:
@@ -47,6 +49,7 @@ steps:
     memory: 512Mi
     region: us-central1
     allow_unauthenticated: true
+    svc_account: 1234-my-svc-account@google.svcaccount.com
     secrets:
       - source: google_credentials
         target: token

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/oliver006/drone-cloud-run
+
+go 1.12

--- a/main.go
+++ b/main.go
@@ -125,6 +125,9 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 		args = append(args, "--image", cfg.ImageName)
 		args = append(args, "--project", cfg.Project)
 
+		// todo: make this configurable
+		args = append(args, "--platform", "managed")
+
 		if len(cfg.EnvSecrets) > 0 || len(cfg.Environment) > 0 {
 			e := make([]string, len(cfg.EnvSecrets))
 			copy(e, cfg.EnvSecrets)

--- a/main_test.go
+++ b/main_test.go
@@ -125,6 +125,7 @@ func TestParseAndRunConfig(t *testing.T) {
 			env: map[string]string{
 				"PLUGIN_ACTION":                "deploy",
 				"PLUGIN_TOKEN":                 validGCPKey,
+				"PLUGIN_SVC_ACCOUNT":           "1234-my-service-acct@account.com",
 				"PLUGIN_SERVICE":               "my-service",
 				"PLUGIN_IMAGE":                 "my-image",
 				"PLUGIN_ALLOW_UNAUTHENTICATED": "true",


### PR DESCRIPTION
# why 

it turns out that sometimes you want to deploy with one account, and then
you dont want to run the cloudrun as the default - rather you want to use
some configured one with tuned privileges.

# what
this pr:
- adds a flag for the runtime service account
- also makes the "managed" part configurable