### PR TITLE
Adds support for alpha features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ steps:
       runtime: gke                                              # default=managed
       image: org-name/my-api-service-image
       memory: 512Mi
+      alpha: false                                              # use "gcloud alpha run" features, default=false
       region: us-central1
       allow_unauthenticated: true                               # default=false
       svc_account: 1234-my-svc-account@google.svcaccount.com 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ steps:
       service: my-api-service
       runtime: gke                                              # default=managed
       image: org-name/my-api-service-image
+      timeout: 10m                                              # google cloud default is 5m
       memory: 512Mi
       variant: alpha                                            # uses "gcloud alpha run" command variant, default=<empty string>. Other supported variant is beta.
       region: us-central1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ steps:
       runtime: gke                                              # default=managed
       image: org-name/my-api-service-image
       memory: 512Mi
-      alpha: false                                              # use "gcloud alpha run" features, default=false
+      variant: alpha                                            # uses "gcloud alpha run" command variant, default=<empty string>. Other supported variant is beta.
       region: us-central1
       allow_unauthenticated: true                               # default=false
       svc_account: 1234-my-svc-account@google.svcaccount.com 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type Config struct {
 	Project    string
 	Region     string
 	SvcAccount string
+	Alpha      bool
 
 	// deployed service config
 	ServiceName          string
@@ -75,6 +76,7 @@ func parseConfig() (*Config, error) {
 		Region:     os.Getenv("PLUGIN_REGION"),
 		SvcAccount: os.Getenv("PLUGIN_SVC_ACCOUNT"),
 		Token:      os.Getenv("PLUGIN_TOKEN"),
+		Alpha:      os.Getenv("PLUGIN_ALPHA") == "true",
 
 		ServiceName:          os.Getenv("PLUGIN_SERVICE"),
 		ImageName:            os.Getenv("PLUGIN_IMAGE"),
@@ -144,8 +146,14 @@ func parseConfig() (*Config, error) {
 func CreateExecutionPlan(cfg *Config) ([]string, error) {
 	args := []string{
 		"--quiet",
-		"run",
 	}
+
+	if cfg.Alpha {
+		args = append(args, "alpha")
+	}
+
+	args = append(args, "run")
+
 	switch cfg.Action {
 	case "deploy":
 		args = append(args, "deploy")

--- a/main.go
+++ b/main.go
@@ -192,6 +192,10 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 			args = append(args, "--memory", cfg.Memory)
 		}
 
+		if cfg.Timeout != "" {
+			args = append(args, "--timeout", cfg.Timeout)
+		}
+
 		if cfg.Region != "" {
 			args = append(args, "--region", cfg.Region)
 		}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Config struct {
 	Project    string
 	Region     string
 	SvcAccount string
-	Alpha      bool
+	Variant    string
 
 	// deployed service config
 	ServiceName          string
@@ -76,7 +76,7 @@ func parseConfig() (*Config, error) {
 		Region:     os.Getenv("PLUGIN_REGION"),
 		SvcAccount: os.Getenv("PLUGIN_SVC_ACCOUNT"),
 		Token:      os.Getenv("PLUGIN_TOKEN"),
-		Alpha:      os.Getenv("PLUGIN_ALPHA") == "true",
+		Variant:    os.Getenv("PLUGIN_VARIANT"),
 
 		ServiceName:          os.Getenv("PLUGIN_SERVICE"),
 		ImageName:            os.Getenv("PLUGIN_IMAGE"),
@@ -148,8 +148,8 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 		"--quiet",
 	}
 
-	if cfg.Alpha {
-		args = append(args, "alpha")
+	if cfg.Variant != "" && (cfg.Variant == "alpha" || cfg.Variant == "beta") {
+		args = append(args, cfg.Variant)
 	}
 
 	args = append(args, "run")

--- a/main_test.go
+++ b/main_test.go
@@ -231,6 +231,15 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedOk:        false,
 			cfgExpectedProjectId: "my-project-id",
 		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_ALPHA": "true"},
+			planExpectedOk:       true,
+			cfgExpectedOk:        true,
+			cfgExpectedProjectId: "my-project-id",
+		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
 		t.Run(name, func(t *testing.T) {
@@ -286,6 +295,10 @@ func TestParseAndRunConfig(t *testing.T) {
 				t.Fatalf("Expected plan to fail, got plan: %v   env: %#v", plan, tst.env)
 			}
 			t.Logf("plan: %v", plan)
+
+			if cfg.Alpha && plan[1] != "alpha" {
+				t.Fatal("execution plan should contain \"alpha\"")
+			}
 
 			for _, flg := range tst.planExpectedFlags {
 				found := false

--- a/main_test.go
+++ b/main_test.go
@@ -235,7 +235,16 @@ func TestParseAndRunConfig(t *testing.T) {
 			env: map[string]string{
 				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
 				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
-				"PLUGIN_ALPHA": "true"},
+				"PLUGIN_VARIANT": "alpha"},
+			planExpectedOk:       true,
+			cfgExpectedOk:        true,
+			cfgExpectedProjectId: "my-project-id",
+		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_VARIANT": "beta"},
 			planExpectedOk:       true,
 			cfgExpectedOk:        true,
 			cfgExpectedProjectId: "my-project-id",
@@ -296,8 +305,16 @@ func TestParseAndRunConfig(t *testing.T) {
 			}
 			t.Logf("plan: %v", plan)
 
-			if cfg.Alpha && plan[1] != "alpha" {
-				t.Fatal("execution plan should contain \"alpha\"")
+			if cfg.Variant == "alpha" && plan[1] != "alpha" {
+				t.Fatal("execution plan should contain \"alpha\" for variant=alpha")
+			}
+
+			if cfg.Variant == "beta" && plan[1] != "beta" {
+				t.Fatal("execution plan should contain \"beta\" for variant=beta")
+			}
+
+			if cfg.Variant == "" && len(plan) > 0 && plan[1] != "run" { // len(plan) is 0 for "gcloud version" command test
+				t.Fatal("execution plan shouldn't contain any variant for variant=<empty string>")
 			}
 
 			for _, flg := range tst.planExpectedFlags {


### PR DESCRIPTION
Closes #9.

This add an option `alpha` to set alpha on to the generated command. This PR also adds a test for alpha command. 

This will automatically make beta features available with alpha option.

Let us know if you would rather use `beta` command exclusively.