### PR TITLE
Optionally run 'gcloud run services update-traffic' after a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ steps:
     image: oliver006/drone-cloud-run:latest
     pull: always
     settings:
-      action: deploy
+      action: deploy                                            # other actions: update-traffic
       service: my-api-service
       runtime: gke                                              # default=managed
       image: org-name/my-api-service-image
@@ -25,10 +25,8 @@ steps:
       region: us-central1
       allow_unauthenticated: true                               # default=false
       svc_account: 1234-my-svc-account@google.svcaccount.com 
-      addl_flags: 
+      addl_flags:                                               # if present, flags passed to command
         add-cloud-sql-instances: instance1,instance2
-      update_traffic:                                           # if present, flags passed to gcloud run services update-traffic. default=command not run.
-        to-latest: ""
       token:
         from_secret: google_credentials
       environment:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,48 @@ steps:
 
 ```
 
+### Updating traffic
+
+You can optionally use the `update-traffic` action to change which revisions
+will receive traffic by passing the [`services update-traffic`](https://cloud.google.com/sdk/gcloud/reference/alpha/run/services/update-traffic)
+command's `--to-latest`, `--to-revisions` or `--to-tags` arguments to `addl_flags`.
+
+See the [Cloud Run traffic routing](https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration)
+docs for more information.
+
+```
+kind: pipeline
+name: default
+
+steps:
+  - name: deploy-using-new-drone-plugin-version                 # Same options available as above
+    image: oliver006/drone-cloud-run:latest
+    settings:
+      action: deploy
+      variant: alpha
+      service: my-api-service
+      runtime: gke
+      image: org-name/my-api-service-image
+      region: us-central1
+      addl_flags:
+        no-traffic: ''                                          # Don't route 100% of traffic to this revision by default
+        tag: canary                                             # Human-readable revision name
+      token:
+        from_secret: google_credentials
+
+  - name: update-traffic-using-new-drone-plugin-version
+    image: oliver006/drone-cloud-run:latest
+    settings:
+      action: update-traffic
+      variant: alpha
+      service: my-api-service
+      runtime: gke
+      region: us-central1
+      addl_flags:
+        to-tags: canary=5                                       # One of: to-latest, to-revisions, to-tags (alpha variant only)
+      token:
+        from_secret: google_credentials
+```
 
 ## On Additional Flags
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ steps:
       svc_account: 1234-my-svc-account@google.svcaccount.com 
       addl_flags: 
         add-cloud-sql-instances: instance1,instance2
+      update_traffic:                                           # if present, flags passed to gcloud run services update-traffic. default=command not run.
+        to-latest: ""
       token:
         from_secret: google_credentials
       environment:

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func parseConfig() (*Config, error) {
 	if cfg.ImageName == "" {
 		// for Drone v0.8 compat. as 'image' clashes since settings are passed top-level
 		cfg.ImageName = os.Getenv("PLUGIN_DEPLOYMENT_IMAGE")
-		if cfg.ImageName == "" {
+		if cfg.ImageName == "" && cfg.Action == "deploy" {
 			return nil, fmt.Errorf("Missing image/deployment_image name")
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -159,8 +159,6 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 		args = append(args, "deploy")
 		args = append(args, cfg.ServiceName)
 		args = append(args, "--image", cfg.ImageName)
-		args = append(args, "--project", cfg.Project)
-		args = append(args, "--platform", cfg.Runtime)
 
 		if cfg.SvcAccount != "" {
 			args = append(args, "--service-account", cfg.SvcAccount)
@@ -196,44 +194,27 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 			args = append(args, "--timeout", cfg.Timeout)
 		}
 
-		if cfg.Region != "" {
-			args = append(args, "--region", cfg.Region)
-		}
-
-		for flg, argStr := range cfg.AdditionalFlags {
-			if argStr != "" {
-				args = append(args, fmt.Sprintf("--%s=%s", flg, argStr))
-			} else {
-				args = append(args, fmt.Sprintf("--%s", flg))
-			}
-		}
-
 	case "update-traffic":
 		args = append(args, "services", "update-traffic")
 		args = append(args, cfg.ServiceName)
 
-		if cfg.Project != "" {
-			args = append(args, "--project", cfg.Project)
-		}
-
-		if cfg.Runtime != "" {
-			args = append(args, "--platform", cfg.Runtime)
-		}
-
-		if cfg.Region != "" {
-			args = append(args, "--region", cfg.Region)
-		}
-
-		for flg, argStr := range cfg.AdditionalFlags {
-			if argStr != "" {
-				args = append(args, fmt.Sprintf("--%s=%s", flg, argStr))
-			} else {
-				args = append(args, fmt.Sprintf("--%s", flg))
-			}
-		}
-
 	default:
 		return []string{}, fmt.Errorf("action: %s not implemented yet", cfg.Action)
+	}
+
+	args = append(args, "--project", cfg.Project)
+	args = append(args, "--platform", cfg.Runtime)
+
+	if cfg.Region != "" {
+		args = append(args, "--region", cfg.Region)
+	}
+
+	for flg, argStr := range cfg.AdditionalFlags {
+		if argStr != "" {
+			args = append(args, fmt.Sprintf("--%s=%s", flg, argStr))
+		} else {
+			args = append(args, fmt.Sprintf("--%s", flg))
+		}
 	}
 
 	return args, nil

--- a/main_test.go
+++ b/main_test.go
@@ -83,13 +83,15 @@ func TestGetProjectFromToken(t *testing.T) {
 
 func TestParseAndRunConfig(t *testing.T) {
 	for _, tst := range []struct {
-		env                   map[string]string
-		cfgExpectedOk         bool
-		cfgExpectedProjectId  string
-		cfgExpectedEnvSecrets []string
-		cfgExpectedEnvKeys    []string
-		planExpectedOk        bool
-		planExpectedFlags     []string
+		env                      map[string]string
+		cfgExpectedOk            bool
+		cfgExpectedProjectId     string
+		cfgExpectedEnvSecrets    []string
+		cfgExpectedEnvKeys       []string
+		planExpectedOk           bool
+		planExpectedFlags        []string
+		trafficPlanExpectedOk    bool
+		trafficPlanExpectedFlags []string
 	}{
 		{
 			cfgExpectedOk:        true,
@@ -139,6 +141,15 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedProjectId: "my-project-id",
 			planExpectedOk:       true,
 			planExpectedFlags:    []string{"--remove-cloudsql-instances=my-proj:east2:db2"},
+		},
+
+		// shared flags (platform, project, ...) included in final command
+		{
+			cfgExpectedOk:        true,
+			env:                  map[string]string{"PLUGIN_ACTION": "deploy", "PLUGIN_TOKEN": validGCPKey, "PLUGIN_SERVICE": "my-service", "PLUGIN_IMAGE": "my-image", "PLUGIN_REGION": "us-east1"},
+			cfgExpectedProjectId: "my-project-id",
+			planExpectedOk:       true,
+			planExpectedFlags:    []string{"--project=my-project-id", "--platform=managed", "--region=us-east1"},
 		},
 
 		// parses ok but action is unknown
@@ -249,6 +260,28 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedOk:        true,
 			cfgExpectedProjectId: "my-project-id",
 		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_UPDATE_TRAFFIC": `{"to-latest":""}`},
+			planExpectedOk:           true,
+			cfgExpectedOk:            true,
+			cfgExpectedProjectId:     "my-project-id",
+			trafficPlanExpectedOk:    true,
+			trafficPlanExpectedFlags: []string{"--to-latest"},
+		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_UPDATE_TRAFFIC": `{"to-tags":"tag=100"}`},
+			planExpectedOk:           true,
+			cfgExpectedOk:            true,
+			cfgExpectedProjectId:     "my-project-id",
+			trafficPlanExpectedOk:    true,
+			trafficPlanExpectedFlags: []string{"--to-tags=tag=100"},
+		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
 		t.Run(name, func(t *testing.T) {
@@ -297,12 +330,26 @@ func TestParseAndRunConfig(t *testing.T) {
 				return
 			}
 
+			scope, err := CreateServiceScope(cfg)
+			if err != nil && tst.planExpectedOk {
+				t.Fatalf("plan was expected to be ok, CreateServiceScope got err: %s", err)
+			}
+
 			plan, err := CreateExecutionPlan(cfg)
 			if err != nil && tst.planExpectedOk {
 				t.Fatalf("plan was expected to be ok, got err: %s", err)
 			} else if err == nil && !tst.planExpectedOk {
 				t.Fatalf("Expected plan to fail, got plan: %v   env: %#v", plan, tst.env)
 			}
+			t.Logf("env: %#v", tst.env)
+			plan = append(plan, scope...)
+			t.Logf("plan: %v", plan)
+
+			trafficPlan, err := CreateUpdateTrafficPlan(cfg)
+			if err != nil && tst.trafficPlanExpectedOk {
+				t.Fatalf("trafficPlan was expected to be ok, got err: %s with plan %s", err, trafficPlan)
+			}
+			trafficPlan = append(trafficPlan, scope...)
 			t.Logf("plan: %v", plan)
 
 			if cfg.Variant == "alpha" && plan[1] != "alpha" {
@@ -313,7 +360,7 @@ func TestParseAndRunConfig(t *testing.T) {
 				t.Fatal("execution plan should contain \"beta\" for variant=beta")
 			}
 
-			if cfg.Variant == "" && len(plan) > 0 && plan[1] != "run" { // len(plan) is 0 for "gcloud version" command test
+			if cfg.Variant == "" && len(plan) > 0 && tst.planExpectedOk && plan[1] != "run" { // len(plan) is 0 for "gcloud version" command test
 				t.Fatal("execution plan shouldn't contain any variant for variant=<empty string>")
 			}
 
@@ -326,7 +373,20 @@ func TestParseAndRunConfig(t *testing.T) {
 					}
 				}
 				if !found {
-					t.Fatalf("couldn't find expected flag [%s] in [%v]", flg, plan)
+					t.Fatalf("couldn't find expected flag [%s] in [%v] for execution plan", flg, plan)
+				}
+			}
+
+			for _, flg := range tst.trafficPlanExpectedFlags {
+				found := false
+				for _, pflg := range trafficPlan {
+					if pflg == flg {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("couldn't find expected flag [%s] in [%v] for traffic plan", flg, trafficPlan)
 				}
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -341,12 +341,7 @@ func TestParseAndRunConfig(t *testing.T) {
 				return
 			}
 
-			scope, err := CreateServiceScope(cfg)
-			if err != nil && tst.planExpectedOk {
-				t.Fatalf("plan was expected to be ok, CreateServiceScope got err: %s", err)
-			}
-
-			plan, err := CreateExecutionPlan(cfg, scope)
+			plan, err := CreateExecutionPlan(cfg)
 			if err != nil && tst.planExpectedOk {
 				t.Fatalf("plan was expected to be ok, got err: %s", err)
 			} else if err == nil && !tst.planExpectedOk {
@@ -354,7 +349,7 @@ func TestParseAndRunConfig(t *testing.T) {
 			}
 			t.Logf("plan: %v", plan)
 
-			trafficPlan, err := CreateUpdateTrafficPlan(cfg, scope)
+			trafficPlan, err := CreateUpdateTrafficPlan(cfg)
 			if err != nil && tst.trafficPlanExpectedOk {
 				t.Fatalf("trafficPlan was expected to be ok, got err: %s with plan %s", err, trafficPlan)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -269,7 +269,18 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedOk:            true,
 			cfgExpectedProjectId:     "my-project-id",
 			trafficPlanExpectedOk:    true,
-			trafficPlanExpectedFlags: []string{"--to-latest"},
+			trafficPlanExpectedFlags: []string{"my-service"},
+		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_UPDATE_TRAFFIC": `{"to-latest":""}`},
+			planExpectedOk:           true,
+			cfgExpectedOk:            true,
+			cfgExpectedProjectId:     "my-project-id",
+			trafficPlanExpectedOk:    true,
+			trafficPlanExpectedFlags: []string{"services", "update-traffic", "--to-latest"},
 		},
 		{
 			env: map[string]string{
@@ -335,21 +346,18 @@ func TestParseAndRunConfig(t *testing.T) {
 				t.Fatalf("plan was expected to be ok, CreateServiceScope got err: %s", err)
 			}
 
-			plan, err := CreateExecutionPlan(cfg)
+			plan, err := CreateExecutionPlan(cfg, scope)
 			if err != nil && tst.planExpectedOk {
 				t.Fatalf("plan was expected to be ok, got err: %s", err)
 			} else if err == nil && !tst.planExpectedOk {
 				t.Fatalf("Expected plan to fail, got plan: %v   env: %#v", plan, tst.env)
 			}
-			t.Logf("env: %#v", tst.env)
-			plan = append(plan, scope...)
 			t.Logf("plan: %v", plan)
 
-			trafficPlan, err := CreateUpdateTrafficPlan(cfg)
+			trafficPlan, err := CreateUpdateTrafficPlan(cfg, scope)
 			if err != nil && tst.trafficPlanExpectedOk {
 				t.Fatalf("trafficPlan was expected to be ok, got err: %s with plan %s", err, trafficPlan)
 			}
-			trafficPlan = append(trafficPlan, scope...)
 			t.Logf("plan: %v", plan)
 
 			if cfg.Variant == "alpha" && plan[1] != "alpha" {


### PR DESCRIPTION
When managing multiple tagged revisions in a service, you often want to adjust the traffic allocation right after a deployment. Some examples:
* Whenever `main` is pushed, serve 100% of traffic to the new revision even if other tags exist (`--to-latest`)
* New deploys are given a `canary` tag and 5% of traffic is routed to it (`--tags canary=5`)

Unfortunately, this is handled by a second command, `gcloud run services update-traffic`, so it doesn't seem trivial to add into the current `deploy` action. However, this feels like it could be common enough a use-case to build into the plugin.

One way to do that which I followed in this PR is to run a command after `deploy`, similar to how `gcloud auth activate-service-account` is run before it. This example:
* adds a `CreateUpdateTrafficPlan` similar to `CreateExecutionPlan`
* runs the traffic plan if the execution plan succeeds
* relies on a map of `update_traffic` options, similar to `addl_flags`, to pass any valid options to the command

```yaml
steps:
  - image: oliver006/drone-cloud-run:latest
    settings:
      action: deploy
      service: my-api-service
      runtime: gke                                              # default=managed
      image: org-name/my-api-service-image
      region: us-central1
      update_traffic:
        to-latest: ""
...
      update_traffic:
        to-tags: canary=5
```