### PR TITLE
Use 'slim' variant of google/cloud-sdk docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN BUILD_DATE=$(date +%F-%T) && CGO_ENABLED=0 GOOS=linux go build -o drone-clou
 RUN ./drone-cloud-run -v
 
 
-FROM       google/cloud-sdk:latest as release
+FROM       google/cloud-sdk:slim as release
 RUN        apt-get -y install ca-certificates
 COPY       --from=builder /go/src/github.com/oliver006/drone-cloud-run/drone-cloud-run /bin/drone-cloud-run
 ENTRYPOINT /bin/drone-cloud-run


### PR DESCRIPTION
This brought the resulting image down to about a third of the original size when I was testing, and includes the `alpha` and `beta` commands as well.

It didn't look like we'd be losing any functionality, but the full table of supported commands is available here: https://github.com/GoogleCloudPlatform/cloud-sdk-docker#components-installed-in-each-tag