### PR TITLE
Support allow_unauthenticated: false

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,8 +178,11 @@ func CreateExecutionPlan(cfg *Config) ([]string, error) {
 			args = append(args, "--set-env-vars", envStr)
 		}
 
+		// If --quiet and none selected, GCP defaults to --no-allow-unauthenticated
 		if cfg.AllowUnauthenticated {
 			args = append(args, "--allow-unauthenticated")
+		} else {
+			args = append(args, "--no-allow-unauthenticated")
 		}
 
 		if cfg.Concurrency != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -278,6 +278,36 @@ func TestParseAndRunConfig(t *testing.T) {
 			cfgExpectedProjectId: "my-project-id",
 			planExpectedFlags:    []string{"--to-tags=tag=100"},
 		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_ALLOW_UNAUTHENTICATED": "true"},
+			planExpectedOk:       true,
+			cfgExpectedOk:        true,
+			cfgExpectedProjectId: "my-project-id",
+			planExpectedFlags:    []string{"--allow-unauthenticated"},
+		},
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey,
+				"PLUGIN_ALLOW_UNAUTHENTICATED": "false"},
+			planExpectedOk:       true,
+			cfgExpectedOk:        true,
+			cfgExpectedProjectId: "my-project-id",
+			planExpectedFlags:    []string{"--no-allow-unauthenticated"},
+		},
+		// gcloud defaults to --no-allow-unauthenticated if parameter not passed
+		{
+			env: map[string]string{
+				"PLUGIN_ACTION": "deploy", "PLUGIN_SERVICE": "my-service",
+				"PLUGIN_IMAGE": "my-image", "PLUGIN_TOKEN": validGCPKey},
+			planExpectedOk:       true,
+			cfgExpectedOk:        true,
+			cfgExpectedProjectId: "my-project-id",
+			planExpectedFlags:    []string{"--no-allow-unauthenticated"},
+		},
 	} {
 		name := fmt.Sprintf("env:[%s]", tst.env)
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
At the moment, the `allow_unauthenticated` option can only add `--allow-unauthenticated` to the list of flags, not the reverse form, `--no-allow-unauthenticated`.

If you leave the option blank when deploying for the first time, no flag is passed, and GCP will correctly default to disabling unauthenticated requests. However, once a service has already been deployed allowing unauthed reqs, not passing that flag will just keep the existing, meaning there's no way to subsequently disable unauthed requests. (Ran into this when changing `allow_unauthenticated: true` to `allow_unauthenticated: false`, and nothing changed.)

This PR adds an explicit `else` when checking `allow_unauthenticated`, so that it always adds either `--allow` or `--no-allow`. It should also preserve the existing default behavior if no option is set.