### PR TITLE
gcloud SDK 356.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN BUILD_DATE=$(date +%F-%T) && CGO_ENABLED=0 GOOS=linux go build -o drone-clou
 RUN ./drone-cloud-run -v
 
 
-FROM       gcr.io/google.com/cloudsdktool/cloud-sdk:348.0.0-slim as release
+FROM       gcr.io/google.com/cloudsdktool/cloud-sdk:356.0.0-slim as release
 RUN        apt-get -y install ca-certificates
 COPY       --from=builder /go/src/github.com/oliver006/drone-cloud-run/drone-cloud-run /bin/drone-cloud-run
 ENTRYPOINT /bin/drone-cloud-run


### PR DESCRIPTION
Bump gcloud version to [356.0.0](https://cloud.google.com/sdk/docs/release-notes#35600_2021-09-08).