### PR TITLE
Switch to use alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as builder
+FROM golang:1.19-alpine as builder
 WORKDIR /go/src/github.com/oliver006/drone-cloud-run
 
 ARG SHA1
@@ -11,7 +11,7 @@ RUN BUILD_DATE=$(date +%F-%T) && CGO_ENABLED=0 GOOS=linux go build -o drone-clou
     -ldflags "-s -w -extldflags \"-static\" -X main.BuildHash=$SHA1 -X main.BuildTag=$TAG -X main.BuildDate=$BUILD_DATE" .
 RUN ./drone-cloud-run -v
 
-FROM       gcr.io/google.com/cloudsdktool/cloud-sdk:392.0.0-alpine as release
+FROM       gcr.io/google.com/cloudsdktool/cloud-sdk:405.0.0-alpine as release
 RUN        apk --no-cache add ca-certificates
 COPY       --from=builder /go/src/github.com/oliver006/drone-cloud-run/drone-cloud-run /bin/drone-cloud-run
 ENTRYPOINT /bin/drone-cloud-run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.16-alpine as builder
 WORKDIR /go/src/github.com/oliver006/drone-cloud-run
 
 ARG SHA1
@@ -11,7 +11,7 @@ RUN BUILD_DATE=$(date +%F-%T) && CGO_ENABLED=0 GOOS=linux go build -o drone-clou
     -ldflags "-s -w -extldflags \"-static\" -X main.BuildHash=$SHA1 -X main.BuildTag=$TAG -X main.BuildDate=$BUILD_DATE" .
 RUN ./drone-cloud-run -v
 
-FROM       gcr.io/google.com/cloudsdktool/cloud-sdk:392.0.0-slim as release
-RUN        apt-get -y install ca-certificates
+FROM       gcr.io/google.com/cloudsdktool/cloud-sdk:392.0.0-alpine as release
+RUN        apk --no-cache add ca-certificates
 COPY       --from=builder /go/src/github.com/oliver006/drone-cloud-run/drone-cloud-run /bin/drone-cloud-run
 ENTRYPOINT /bin/drone-cloud-run


### PR DESCRIPTION
I've noticed that the Docker compressed image size is ~430 MB, largely driven by the size of the [cloud-sdk:slim image](https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/GLOBAL/cloud-sdk).

Is there a reason not to swap to use alpine images?  I've tested this build locally and it appears to work just as well as -slim.  This brings the compressed image size down to ~200 MB.